### PR TITLE
Resolve current state of NaN

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ export default class Rotation extends Component {
 
   handleWheel(e) {
     e.preventDefault();
-    const delta = e.deltaY / Math.abs(e.deltaY);
+    const delta = e.deltaY === 0 ? 0 : e.deltaY / Math.abs(e.deltaY);
     this.show(this.state.current + delta);
   }
 


### PR DESCRIPTION
Fixes #1

Caught by setting a conditional breakpoint in render function with a simplified version of the loop.
```js
! this.props.data.map(function (src, i) { return _this.state.current === i ? 'block' : 'none'; }).join('').match('block')
```

This is because `e.deltaY` can be `0` or `-0`. which means we have a divide-by-0 leading to `delta = NaN`  and a permanent state in the render function where nothing gets out of hidden.