### PR TITLE
Fix autoplay

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ export default class Rotation extends Component {
       this.setCurrentFrame(reverse ? current - 1 : current + 1)
     }
 
-    this.nextTimeout = setTimeout(() => {
+    this.nextTimeout = autoPlay && setTimeout(() => {
       this.nextFrame()
     }, playTimeout)
   }


### PR DESCRIPTION
Example code to issue reproduce: 
`<Rotation cycle={true}
                  autoPlay={this.state.autoPlay}
                  onChange={(frame) => {
                  if (frame === 10) {
                    this.setState({
                      autoPlay: false
                    })`

Expected behavior: Start initially autoPlay then stop spinning after 10 frame.

Issue: The prop autoPlay changes to false, method stop fires but spinning doesn't stop because of async setTimeout in `nextFrame` method